### PR TITLE
Add CI integration configs on appveyor and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,31 @@
 language: go
-sudo: false
 
-addons:
-        apt:
-                packages:
-                        - libpcsclite-dev
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      go: 1.5.x
+    - os: linux
+      dist: trusty
+      go: 1.6.x
+    - os: linux
+      dist: trusty
+      go: 1.7.x
+    - os: linux
+      dist: trusty
+      go: 1.8.x
+    - os: linux
+      dist: trusty
+      go: 1.9.x
+    - os: linux
+      dist: precise
+      go: 1.9.x
+    - os: linux
+      dist: precise
+      go: 1.10.x
+    - os: osx
+      go: 1.10.x
 
-os:
-        - linux
-        - osx
-
-go:
-        - 1.5.x
-        - 1.6.x
-        - 1.7.x
-        - 1.8.x
-        - 1.9.x
-        - 1.10.x
-        - tip
+script:
+  - go install ./...
+  - go test -v ./...

--- a/README.md
+++ b/README.md
@@ -1,13 +1,22 @@
 scard
 =====
 
-[![GoDoc](https://godoc.org/github.com/ebfe/scard?status.svg)](https://godoc.org/github.com/ebfe/scard)
+[![Travis][travisimg]][travisurl]
+[![AppVeyor][appveyorimg]][appveyorurl]
+[![GoDoc][docimg]][docurl]
+
+[travisimg]:   https://travis-ci.org/Arachnid/scard.svg?branch=master
+[travisurl]:   https://travis-ci.org/Arachnid/scard
+[appveyorimg]: https://ci.appveyor.com/api/projects/status/pleasefillmein/branch/master?svg=true
+[appveyorurl]: https://ci.appveyor.com/project/Arachnid/scard
+[docimg]:      https://godoc.org/github.com/Arachnid/scard?status.svg
+[docurl]:      https://godoc.org/github.com/Arachnid/scard
 
 Go bindings to the PC/SC API.
 
 ## Installation
 
-	go get github.com/ebfe/scard
+	go get -u github.com/Arachnid/scard
 
 ## Bugs
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,32 @@
+os: Visual Studio 2015
+
+# Clone directly into GOPATH.
+clone_folder: C:\gopath\src\github.com\Arachnid\scard
+clone_depth: 1
+version: "{branch}.{build}"
+environment:
+  global:
+    GOPATH: C:\gopath
+    CC: gcc.exe
+  matrix:
+    - GOARCH: amd64
+      MSYS2_ARCH: x86_64
+      MSYS2_BITS: 64
+      MSYSTEM: MINGW64
+      PATH: C:\msys64\mingw64\bin\;%PATH%
+    - GOARCH: 386
+      MSYS2_ARCH: i686
+      MSYS2_BITS: 32
+      MSYSTEM: MINGW32
+      PATH: C:\msys64\mingw32\bin\;%PATH%
+
+install:
+  - rmdir C:\go /s /q
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.10.1.windows-%GOARCH%.zip
+  - 7z x go1.10.1.windows-%GOARCH%.zip -y -oC:\ > NUL
+  - go version
+  - gcc --version
+
+build_script:
+  - go install ./...
+  - go test -v ./...


### PR DESCRIPTION
This PR drops the `libpcsclite-dev` dependency from Travis to correctly test whether the lib is self contained, enables Travis on a variety of platforms and also adds Appveyor. This ensures we're testing on Linux, OSX and Windows too any self containment code.